### PR TITLE
doveadm: let the doveadm-server do the iterating

### DIFF
--- a/src/doveadm/doveadm-mail.c
+++ b/src/doveadm/doveadm-mail.c
@@ -481,8 +481,9 @@ doveadm_mail_all_users(struct doveadm_mail_cmd_context *ctx,
 
 	ctx->v.init(ctx, ctx->args);
 
-	mail_storage_service_all_init_mask(ctx->storage_service,
-		wildcard_user != NULL ? wildcard_user : "");
+	if (ctx->users_list_input == NULL)
+		mail_storage_service_all_init_mask(ctx->storage_service,
+			wildcard_user != NULL ? wildcard_user : "");
 
 	if (hook_doveadm_mail_init != NULL)
 		hook_doveadm_mail_init(ctx);

--- a/src/doveadm/doveadm-mail.h
+++ b/src/doveadm/doveadm-mail.h
@@ -74,7 +74,7 @@ struct doveadm_mail_cmd_context {
 	struct mail_storage_service_input storage_service_input;
 	/* search args aren't set for all mail commands */
 	struct mail_search_args *search_args;
-	struct istream *users_list_input;
+	const char *const *users_list;
 
 	struct mail_storage_service_user *cur_service_user;
 	struct mail_user *cur_mail_user;

--- a/src/lib-storage/mail-storage-service.c
+++ b/src/lib-storage/mail-storage-service.c
@@ -1652,6 +1652,11 @@ void mail_storage_service_deinit(struct mail_storage_service_ctx **_ctx)
 	}
 	if (ctx->set_cache != NULL)
 		master_service_settings_cache_deinit(&ctx->set_cache);
+	if ((ctx->flags & MAIL_STORAGE_SERVICE_FLAG_TEMP_PRIV_DROP) != 0 &&
+	    geteuid() != 0) {
+		/* we previously dropped privileges. switch back to root again */
+		mail_storage_service_seteuid_root();
+	}
 	pool_unref(&ctx->pool);
 
 	module_dir_unload(&mail_storage_service_modules);


### PR DESCRIPTION
We recently started issuing more commands over `doveadm-server` instead of manipulating the mailbox ourself and I noticed that `doveadm-server` starts slowing down if a command is issued for more users. Main reason for this is `doveadm` is sending a single request for every user and the per-request overhead of `doveadm-server` is high.

For example fetching the current quota of 5000 mailboxes (`quota = maildir`) takes about 1.2 seconds with `doveadm` as worker vs. about 9 seconds with `doveadm-server`.

Since `doveadm` already passes the commandline arguments over to the server I modified `doveadm` so iterating happens on server-side (62158ccd46737557a3704965597aad2256cd4e54). e.g. For `doveadm quota get -S /../dovadm-server -A` or `doveadm quota get -S /../dovadm-server -u m*lbox`  the users are now iterated on server-side. Since this requires fetching the userlist from `auth-userdb` we have to make sure `doveadm-server` has the required privileges to do so (3a55b5e8a21d8c0b588738599dae9207190fdeee).

Additional I implemented support for passing multiple users to the server (8340aad647b7047c46a23d9617f0a509583e0d61). e.g  `echo -e "mailbox1\nmailbox2\nmailbox3" | doveadm quota get -S /../dovadm-server -F -` only fetches quota for these three mailboxes.

I've split the change in a couple of commits so you can better track the intent.